### PR TITLE
Fix/remove env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,4 @@ services:
 networks:
   imai-network:
     driver: bridge
-  imai-network:
-    driver: bridge
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-    env_file:
-      - .env
     networks:
       - imai-network
 
 networks:
+  imai-network:
+    driver: bridge
   imai-network:
     driver: bridge


### PR DESCRIPTION
This pull request makes a small adjustment to the Docker Compose configuration. The change removes the use of the `env_file` directive for the service environment, which previously loaded environment variables from the `.env` file.